### PR TITLE
Fix side value in reversal watchers

### DIFF
--- a/backend/core/btc_reversal_watcher.py
+++ b/backend/core/btc_reversal_watcher.py
@@ -44,7 +44,8 @@ class BTCReversalWatcher:
                 self.logger.info(f"Открытые позиции: {positions}")
             for pos in positions:
                 profit = pos.get('profit') or pos.get('pnl') or pos.get('unrealized_pnl') or 0
-                side = pos.get('side', '').lower()  # 'long' или 'short'
+                raw_side = pos.get('side', '').lower()  # 'buy' или 'sell'
+                side = 'long' if raw_side == 'buy' else 'short' if raw_side == 'sell' else raw_side
                 if self.logger:
                     self.logger.info(f"Проверка позиции: {pos}, прибыль: {profit}, side: {side}")
                 # Закрываем только противоположные позиции

--- a/backend/core/pair_reversal_watcher.py
+++ b/backend/core/pair_reversal_watcher.py
@@ -57,7 +57,8 @@ class PairReversalWatcher:
                         or pos.get("unrealized_pnl")
                         or 0
                     )
-                    side = pos.get("side", "").lower()
+                    raw_side = pos.get("side", "").lower()  # 'buy' или 'sell'
+                    side = "long" if raw_side == "buy" else "short" if raw_side == "sell" else raw_side
                     if profit > 0 and (
                         (direction == "long" and side == "short")
                         or (direction == "short" and side == "long")


### PR DESCRIPTION
## Summary
- standardize handling of `side` in BTCReversalWatcher and PairReversalWatcher

## Testing
- `python -m py_compile backend/core/btc_reversal_watcher.py backend/core/pair_reversal_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_68886b80d28883209e4649dc22430d8c