### PR TITLE
Optimize positions retrieval in pair reversal watcher

### DIFF
--- a/backend/core/pair_reversal_watcher.py
+++ b/backend/core/pair_reversal_watcher.py
@@ -28,6 +28,7 @@ class PairReversalWatcher:
         self.last_direction: Dict[str, Optional[str]] = {s: None for s in symbols}
 
     async def check_reversals_and_close(self):
+        positions = self.get_open_positions() or []
         for symbol in self.symbols:
             df = self.get_ohlcv(symbol)
             if df is None or len(df) < 50:
@@ -47,7 +48,6 @@ class PairReversalWatcher:
                     self.broadcast({"symbol": symbol, "direction": direction})
                 except Exception:
                     pass
-                positions = self.get_open_positions() or []
                 for pos in positions:
                     if pos.get("symbol") != symbol:
                         continue


### PR DESCRIPTION
## Summary
- load open positions once before looping through symbols

## Testing
- `python -m py_compile backend/core/pair_reversal_watcher.py`
- `pip install -r requirements.txt` *(fails: Failed to build pydantic-core)*
- `pytest -q` *(fails to collect tests due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68886b8b537c83208c99b4714619461d