### PR TITLE
Disable trailing stop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ BYBIT_TESTNET=true
 
 # Торговые настройки
 TRADING_PAIRS=BTCUSDT,ETHUSDT,SOLUSDT,BNBUSDT,DOGEUSDT,XRPUSDT
+TRAILING_STOP_ENABLED=false
 DEFAULT_TRADING_MODE=medium
 
 # Веб-сервер
@@ -176,6 +177,8 @@ PORT=5000
 # Логирование
 LOG_LEVEL=INFO
 ```
+Trailing stop functionality is **disabled by default**. Set `TRAILING_STOP_ENABLED=true` to enable it.
+
 
 ## 🚀 Развертывание
 

--- a/backend/api/rest_api.py
+++ b/backend/api/rest_api.py
@@ -11,6 +11,7 @@ import logging
 import os
 import csv
 from fastapi.responses import StreamingResponse
+from ..utils.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -410,6 +411,8 @@ async def calculate_position_size(request: PositionSizeRequest, trading_engine =
 async def create_trailing_stop(request: TrailingStopRequest, trading_engine = Depends(get_trading_engine)):
     """Создать трейлинг-стоп"""
     try:
+        if not settings.trailing_stop_enabled:
+            raise HTTPException(status_code=503, detail="Trailing stops are disabled")
         if not trading_engine.strategy_manager:
             raise HTTPException(status_code=503, detail="Strategy manager not initialized")
         
@@ -451,6 +454,8 @@ async def create_trailing_stop(request: TrailingStopRequest, trading_engine = De
 async def get_trailing_stops(trading_engine = Depends(get_trading_engine)):
     """Получить список активных трейлинг-стопов"""
     try:
+        if not settings.trailing_stop_enabled:
+            raise HTTPException(status_code=503, detail="Trailing stops are disabled")
         if not trading_engine.strategy_manager:
             raise HTTPException(status_code=503, detail="Strategy manager not initialized")
         
@@ -472,6 +477,8 @@ async def get_trailing_stops(trading_engine = Depends(get_trading_engine)):
 async def remove_trailing_stop(symbol: str, side: str, trading_engine = Depends(get_trading_engine)):
     """Удалить трейлинг-стоп"""
     try:
+        if not settings.trailing_stop_enabled:
+            raise HTTPException(status_code=503, detail="Trailing stops are disabled")
         if not trading_engine.strategy_manager:
             raise HTTPException(status_code=503, detail="Strategy manager not initialized")
         

--- a/backend/core/strategy_manager.py
+++ b/backend/core/strategy_manager.py
@@ -13,6 +13,7 @@ from .signal_processor import SignalProcessor
 from .enhanced_signal_processor import EnhancedSignalProcessor
 from .market_analyzer import MarketAnalyzer
 from .enhanced_risk_manager import EnhancedRiskManager
+from ..utils.config import settings
 
 
 logger = logging.getLogger(__name__)
@@ -255,6 +256,8 @@ class StrategyManager:
     def _get_trailing_stop_recommendations(self, market_analysis: Dict) -> Dict[str, Any]:
         """Получение рекомендаций по трейлинг-стопам"""
         try:
+            if not settings.trailing_stop_enabled:
+                return {}
             regime = market_analysis.get("regime", "sideways")
             volatility = market_analysis.get("volatility", {})
             vol_level = volatility.get("level", "medium")

--- a/backend/core/trading_engine.py
+++ b/backend/core/trading_engine.py
@@ -141,7 +141,7 @@ class TradingEngine:
 
                 # --- [НОВОЕ] Обновление трейлинг-стопов ---
                 # Собираем market_data для всех активных стопов
-                if hasattr(self.risk_manager, 'update_trailing_stops'):
+                if settings.trailing_stop_enabled and hasattr(self.risk_manager, 'update_trailing_stops'):
                     trailing_symbols = set()
                     if hasattr(self.risk_manager, 'trailing_stops'):
                         trailing_symbols = set(stop.symbol for stop in getattr(self.risk_manager, 'trailing_stops', {}).values() if stop.is_active)
@@ -167,7 +167,7 @@ class TradingEngine:
                 # --- [КОНЕЦ НОВОГО БЛОКА] ---
 
                 # --- [НОВОЕ] Гарантия трейлинг-стопа для всех активных позиций ---
-                if hasattr(self, 'active_positions') and hasattr(self.risk_manager, 'trailing_stops'):
+                if settings.trailing_stop_enabled and hasattr(self, 'active_positions') and hasattr(self.risk_manager, 'trailing_stops'):
                     for (symbol, side) in self.active_positions.keys():
                         stop_key = f"{symbol}_{side}"
                         if stop_key not in self.risk_manager.trailing_stops or not self.risk_manager.trailing_stops[stop_key].is_active:
@@ -696,7 +696,7 @@ class TradingEngine:
             )
             if order_result and order_result.get('success') and current_mode.value == "conservative":
                 # Создаём трейлинг-стоп через EnhancedRiskManager только если ордер реально открыт
-                if hasattr(self.risk_manager, 'create_trailing_stop'):
+                if settings.trailing_stop_enabled and hasattr(self.risk_manager, 'create_trailing_stop'):
                     trailing_stop = self.risk_manager.create_trailing_stop(
                         symbol=symbol,
                         side=side,

--- a/backend/utils/config.py
+++ b/backend/utils/config.py
@@ -34,6 +34,11 @@ class Settings(BaseSettings):
         default=["BTCUSDT", "ETHUSDT", "SOLUSDT", "BNBUSDT"],
         description="Trading pairs to monitor"
     )
+
+    trailing_stop_enabled: bool = Field(
+        default=False,
+        description="Enable trailing stop functionality"
+    )
     
     # Risk Management
     risk_mode: str = Field(

--- a/config.example
+++ b/config.example
@@ -11,6 +11,9 @@ RISK_MODE=moderate
 MAX_POSITION_SIZE=100
 TRADING_PAIRS=BTCUSDT,ETHUSDT,SOLUSDT,BNBUSDT
 
+# Trailing stop configuration
+TRAILING_STOP_ENABLED=false
+
 # Server Configuration
 HOST=0.0.0.0
 PORT=5000


### PR DESCRIPTION
## Summary
- add `TRAILING_STOP_ENABLED` setting and update sample config
- respect the setting in StrategyManager, TradingEngine and REST API
- document the new option in README
- clarify default behavior in README (disabled)

## Testing
- `python test_config.py`
- `python test_demo_connection.py` *(fails: certificate verify failed)*
- `python test_port.py`


------
https://chatgpt.com/codex/tasks/task_e_688cf061101c8320b10188d47017f763